### PR TITLE
Fix documentation link anchors in README files

### DIFF
--- a/rollbar_dart/README.md
+++ b/rollbar_dart/README.md
@@ -33,7 +33,7 @@ See the [`example` directory](./example/) for a complete example.
 
 ## Documentation
 
-For complete usage instructions and configuration reference, see our [`rollbar-dart` SDK docs](https://docs.rollbar.com/docs/flutter#rollbar_dart).
+For complete usage instructions and configuration reference, see our [`rollbar-dart` SDK docs](https://docs.rollbar.com/docs/flutter#dart).
 
 ## Release History & Changelog
 

--- a/rollbar_dart/example/README.md
+++ b/rollbar_dart/example/README.md
@@ -4,4 +4,4 @@ Demonstrates how to use the rollbar_dart package.
 
 This example requires a [Rollbar](https://rollbar.com) access token with `post_server_item` scope, which must be set in the [`bin/rollbar_dart_example.dart`](bin/rollbar_dart_example.dart) `main` function.
 
-For complete `rollbar-dart` usage instructions and configuration reference, see our [`rollbar-dart` SDK docs](https://docs.rollbar.com/docs/flutter#rollbar_dart).
+For complete `rollbar-dart` usage instructions and configuration reference, see our [`rollbar-dart` SDK docs](https://docs.rollbar.com/docs/flutter#dart).

--- a/rollbar_flutter/README.md
+++ b/rollbar_flutter/README.md
@@ -65,7 +65,7 @@ Additional platforms will be prioritized based on feedback from users.
 
 ## Documentation
 
-For complete usage instructions and configuration reference, see our [`rollbar-flutter` SDK docs](https://docs.rollbar.com/docs/flutter#rollbar_flutter).
+For complete usage instructions and configuration reference, see our [`rollbar-flutter` SDK docs](https://docs.rollbar.com/docs/flutter#flutter).
 
 ## Release History & Changelog
 

--- a/rollbar_flutter/example/README.md
+++ b/rollbar_flutter/example/README.md
@@ -4,4 +4,4 @@ Demonstrates how to use the rollbar_flutter plugin.
 
 This example requires a [Rollbar](https://rollbar.com) access token with `post_client_item` scope, which must be set in the [`main.dart`](lib/main.dart) `main` function.
 
-For complete `rollbar-flutter` usage instructions and configuration reference, see our [`rollbar-flutter` SDK docs](https://docs.rollbar.com/docs/flutter#rollbar_flutter).
+For complete `rollbar-flutter` usage instructions and configuration reference, see our [`rollbar-flutter` SDK docs](https://docs.rollbar.com/docs/flutter#flutter).


### PR DESCRIPTION
## Description of the change

This change fixes the anchor ids for links pointing to docs.rollbar.com. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
