### PR TITLE
Add `rootPackage` configuration option to enable root project detection.

### DIFF
--- a/rollbar_dart/example/bin/rollbar_dart_example.dart
+++ b/rollbar_dart/example/bin/rollbar_dart_example.dart
@@ -5,6 +5,7 @@ void main() async {
   var config = (ConfigBuilder('<YOUR ROLLBAR TOKEN HERE>')
         ..environment = 'development'
         ..codeVersion = '0.1.0'
+        ..package = 'rollbar_dart_example'
         ..handleUncaughtErrors = true)
       .build();
 

--- a/rollbar_dart/lib/src/api/payload/client.dart
+++ b/rollbar_dart/lib/src/api/payload/client.dart
@@ -7,15 +7,24 @@ class Client {
 
   String osVersion;
 
+  String rootPackage;
+
   Map<String, String> dart;
 
+  /// Converts the object into a Json encodable map.
+  ///
+  /// The `root` field is not supported by the backend as part of the `client` element,
+  /// and it's being sent under the `server` element, though this might change in the future.
+  /// See the file `core_notifier.dart` for details.
   Map<String, dynamic> toJson() {
-    return {
+    var result = <String, dynamic>{
       'locale': locale,
       'hostname': hostname,
       'os': os,
       'os_version': osVersion,
       'dart': dart
     };
+
+    return result;
   }
 }

--- a/rollbar_dart/lib/src/api/payload/data.dart
+++ b/rollbar_dart/lib/src/api/payload/data.dart
@@ -15,8 +15,8 @@ class Data {
   int timestamp;
   Body body;
   Map<String, Object> custom;
-
   Map platformPayload;
+  Map server;
 
   Map<String, dynamic> toJson() {
     var result = {
@@ -34,6 +34,7 @@ class Data {
     addIfNotNull(result, 'code_version', codeVersion);
     addIfNotNull(result, 'custom', custom);
     addIfNotNull(result, 'platform_payload', platformPayload);
+    addIfNotNull(result, 'server', server);
 
     return result;
   }

--- a/rollbar_dart/lib/src/config.dart
+++ b/rollbar_dart/lib/src/config.dart
@@ -10,6 +10,7 @@ class Config {
   final String environment;
   final String framework;
   final String codeVersion;
+  final String package;
   final bool handleUncaughtErrors;
   final bool includePlatformLogs;
   final Transformer Function(Config) transformer;
@@ -21,6 +22,7 @@ class Config {
       this.environment,
       this.framework,
       this.codeVersion,
+      this.package,
       this.handleUncaughtErrors,
       this.includePlatformLogs,
       this.transformer,
@@ -37,6 +39,7 @@ class Config {
       'environment': environment,
       'framework': framework,
       'codeVersion': codeVersion,
+      'package': package,
       'handleUncaughtErrors': handleUncaughtErrors,
       'includePlatformLogs': includePlatformLogs,
       'transformer': transformer,
@@ -51,6 +54,7 @@ class Config {
           ..environment = values['environment']
           ..framework = values['framework']
           ..codeVersion = values['codeVersion']
+          ..package = values['package']
           ..handleUncaughtErrors = values['handleUncaughtErrors']
           ..includePlatformLogs = values['includePlatformLogs']
           ..transformer = values['transformer']
@@ -65,6 +69,8 @@ class ConfigBuilder {
   String environment;
   String framework;
   String codeVersion;
+  String package;
+
   bool handleUncaughtErrors = false;
   bool includePlatformLogs = false;
 
@@ -86,6 +92,7 @@ class ConfigBuilder {
         environment = config.environment,
         framework = config.framework,
         codeVersion = config.codeVersion,
+        package = config.package,
         handleUncaughtErrors = config.handleUncaughtErrors,
         includePlatformLogs = config.includePlatformLogs,
         transformer = config.transformer,
@@ -95,7 +102,7 @@ class ConfigBuilder {
     var sender = this.sender;
     sender ??= _httpSender;
     return Config._(accessToken, endpoint, environment, framework, codeVersion,
-        handleUncaughtErrors, includePlatformLogs, transformer, sender);
+        package, handleUncaughtErrors, includePlatformLogs, transformer, sender);
   }
 }
 

--- a/rollbar_dart/lib/src/core_notifier.dart
+++ b/rollbar_dart/lib/src/core_notifier.dart
@@ -34,6 +34,16 @@ class CoreNotifier {
       Level level, dynamic error, StackTrace stackTrace, String message) async {
     var body = await _prepareBody(message, error, stackTrace);
 
+    var client = Client()
+      ..locale = Platform.localeName
+      ..hostname = Platform.localHostname
+      ..os = Platform.operatingSystem
+      ..osVersion = Platform.operatingSystemVersion
+      ..rootPackage = _config.package
+      ..dart = {
+        'version': Platform.version,
+      };
+
     var data = Data()
       ..body = body
       ..timestamp = DateTime.now().microsecondsSinceEpoch
@@ -42,16 +52,16 @@ class CoreNotifier {
       ..platform = Platform.operatingSystem
       ..framework = _config.framework
       ..codeVersion = _config.codeVersion
-      ..client = (Client()
-        ..locale = Platform.localeName
-        ..hostname = Platform.localHostname
-        ..os = Platform.operatingSystem
-        ..osVersion = Platform.operatingSystemVersion
-        ..dart = {
-          'version': Platform.version,
-        })
+      ..client = client
       ..environment = _config.environment
       ..notifier = {'version': NOTIFIER_VERSION, 'name': NOTIFIER_NAME};
+
+    if (client.rootPackage != null) {
+      // Root detection compatibility, currently checked under the server element
+      var server = {'root': client.rootPackage};
+
+      data.server = server;
+    }
 
     if (_transformer != null) {
       data = await _transformer.transform(error, stackTrace, data);

--- a/rollbar_dart/test/rollbar_test.dart
+++ b/rollbar_dart/test/rollbar_test.dart
@@ -22,6 +22,7 @@ void main() {
             ..environment = 'production'
             ..codeVersion = '0.23.2'
             ..handleUncaughtErrors = false
+            ..package = 'some_package_name'
             ..sender = (_) => sender)
           .build();
 
@@ -39,6 +40,11 @@ void main() {
         expect(payload['data']['code_version'], equals('0.23.2'));
         expect(payload['data']['level'], equals('error'));
 
+        // Project root detection currently uses the `server` element of the payload,
+        // so that's where we include it.
+        var root = getPath(payload, ['data', 'server', 'root']);
+        expect(root, equals('some_package_name'));
+
         var trace = getPath(payload, ['data', 'body', 'trace']);
 
         expect(trace['exception']['class'], equals('ArgumentError'));
@@ -47,7 +53,8 @@ void main() {
       }
     });
 
-    test('If optional fields are not set they should not be added to the payload',
+    test(
+        'If optional fields are not set they should not be added to the payload',
         () async {
       var config = (ConfigBuilder('BlaBlaAccessToken')
             ..environment = 'production'
@@ -69,6 +76,7 @@ void main() {
         expect(data, isNot(contains('framework')));
         expect(data, isNot(contains('custom')));
         expect(data, isNot(contains('platform_payload')));
+        expect(data, isNot(contains('server')));
       }
     });
 

--- a/rollbar_flutter/example/lib/main.dart
+++ b/rollbar_flutter/example/lib/main.dart
@@ -7,6 +7,7 @@ Future<void> main() async {
   var config = (ConfigBuilder('<YOUR ROLLBAR TOKEN HERE>')
         ..environment = 'development'
         ..codeVersion = '0.1.0'
+        ..package = 'rollbar_flutter_example'
         ..handleUncaughtErrors = true
         ..includePlatformLogs = false)
       .build();


### PR DESCRIPTION
## Description of the change

This PR adds a `packageRoot` configuration option, which will be used by the backend to do root project detection. 

The backend currently expects the `root` attribute to be part of the  `server` element, so while in Dart code this is kept in a `client` field, when serializing to Json we move it to a `server` element to ensure project root detection works. The long term goal is to propose changes to the occurrence model to allow the `client` element to include a `root` property or equivalent. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- [ch90522]

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
