### PR TITLE
Removed unused `native_stack_traces` dependency.

### DIFF
--- a/rollbar_dart/pubspec.yaml
+++ b/rollbar_dart/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies: 
   http: '>=0.12.2 <0.14.0'
   stack_trace: '>=1.9.5 <1.11.0'
-  native_stack_traces: '>=0.3.7 <=0.4.0'
 
 dev_dependencies:
   pedantic: '>=1.9.2 <=1.11.0'


### PR DESCRIPTION
## Description of the change

Removed unused `native_stack_traces` dependency.

It was being used at some point to detect obfuscated stack traces, but it was very unreliable, "successfully" parsing any trace that we passed it, and returning garbage.
We ended up using a pretty reliable text content based heuristic to detect native stack traces, so the package is not used, and keeping it adds unnecessary dependency churn.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- [ch90971]

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
