### PR TITLE
Workaround for Android Gradle plugin issue when multiple NDKs are ava…

### DIFF
--- a/.github/apply-ndk-workaround
+++ b/.github/apply-ndk-workaround
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Workaround for an Android Gradle plugin bug in version 3.5.0, which fails to find an NDK if
+# there is more than 1 available.
+# To fix this we need to upgrade the Gradle plugin in our example Flutter project to 4.x, but
+# that's not compatible with Flutter 1, hence this workaround.
+
+set -e
+set -o pipefail
+
+if [ "$GITHUB_ACTIONS" == "" ]; then
+    cat <<-EOH >&2
+ERROR: This is a specific workaround for an Android Gradle plugin bug when
+running as a Github action, it should not be run in any other scenario.
+EOH
+    exit 1
+fi
+
+# This environment variable points to the default NDK, but Gradle apparently ignores it
+if [ -L "$ANDROID_NDK_ROOT" ]; then
+    ANDROID_NDK_ROOT=$(readlink "$ANDROID_NDK_ROOT")
+fi
+
+if [ ! -d "$ANDROID_NDK_ROOT" ]; then
+    echo "NDK root $ANDROID_NDK_ROOT is not a directory" >&2
+    exit 1
+fi
+
+cd "$ANDROID_NDK_ROOT"/..
+
+find . -mindepth 1 -maxdepth 1 -type d | while read l; do
+    name=$(basename "$l")
+    if ! [[ "$name" == "21."* ]]; then
+        destination=$(dirname "$l")/../ndk_$(basename "$l")
+        echo "Moving $l to $destination"
+        mv "$l" "$destination"
+    else
+        echo "Keeping $l as is"
+    fi
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
     - uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8
       with:
         flutter-version: ${{ matrix.flutter_version }}
+    - name: Remove additional NDKs (Android Gradle plugin 3.5.0 workaround)
+      run: |
+        chmod +x .github/apply-ndk-workaround &&
+        .github/apply-ndk-workaround
     - name: Show environment
       run: |
         env
@@ -77,6 +81,10 @@ jobs:
     - uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8
       with:
         flutter-version: ${{ matrix.flutter_version }}
+    - name: Remove additional NDKs (Android Gradle plugin 3.5.0 workaround)
+      run: |
+        chmod +x .github/apply-ndk-workaround &&
+        .github/apply-ndk-workaround
     - name: Show environment
       run: |
         env


### PR DESCRIPTION
## Description of the change

Workaround for Android Gradle plugin issue when multiple NDKs are available.

The Android Gradle plugin version < 4.0 fails to find the NDK if there is more than 1 available.
Recently Github added an additional NDK to the action runner's base image, so our builds are
now failing. We can't upgrade the gradle plugin in our example project, since that would break
compatibility with Flutter 1.

This change adds a step to the action to move the additional NDKs out of Gradle's
sight, which fixes our builds.

The script is not executable and has additional checks to ensure it's not accidentally run or
sourced outside of a Github action.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Fix [ch92407]

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
