### PR TITLE
docs: Add missing import to example code

### DIFF
--- a/rollbar_flutter/README.md
+++ b/rollbar_flutter/README.md
@@ -10,6 +10,7 @@ A simple usage example:
 
 ```dart
 import 'package:flutter/services.dart';
+import 'package:rollbar_dart/rollbar.dart';
 import 'package:rollbar_flutter/rollbar.dart';
 
 Future<void> main() async {


### PR DESCRIPTION
Without this it fails to compile with:

    Error: Method not found: 'ConfigBuilder'.

## Description of the change

Documentation change to include a missing import. Note that this import is present in the `rollbar_flutter` example:

https://github.com/rollbar/rollbar-flutter/blob/33f18af7e4e799dacbbcf199c2ee1671c6df74cc/rollbar_flutter/example/lib/main.dart#L6

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Maintenance
- [ ] New release

## Related issues

N/A

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
