### PR TITLE
Fixes dependency issue #21

### DIFF
--- a/rollbar_flutter/example/pubspec.yaml
+++ b/rollbar_flutter/example/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   cupertino_icons: ^1.0.0
 
 dependency_overrides:
+  rollbar_common:
+    path: ../../rollbar_common
   rollbar_dart:
     path: ../../rollbar_dart
   rollbar_flutter:


### PR DESCRIPTION
## Description of the change

Fixes issue when resolving dependency for the Flutter example project reported in: https://github.com/rollbar/rollbar-flutter/issues/21.

`flutter pub get` should work fine now.

## Type of change

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix https://github.com/rollbar/rollbar-flutter/issues/21

## Checklists

### Development

- [ x ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ x ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ x ] "Ready for review" label attached to the PR and reviewers assigned
- [ x ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
