### PR TITLE
Fixes build error related to Android embedding v2

### DIFF
--- a/rollbar_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/rollbar_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="rollbar_flutter_example"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
## Description of the change

Another small build change that fixes https://github.com/rollbar/rollbar-flutter/issues/27 according to https://flutter.dev/go/android-project-migration.

The project already had Android embedding v2, but was seeing this specific line as reason enough to consider the project not Android embedding v2 compliant.

## Type of change

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix https://github.com/rollbar/rollbar-flutter/issues/27

## Checklists

### Development

- [ x ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ x ] All tests related to the changed code pass in development

### Code review

- [ x ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ x ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
