### PR TITLE
avoid null cast exceptions on FlutterError stack traces

### DIFF
--- a/rollbar_flutter/lib/src/rollbar.dart
+++ b/rollbar_flutter/lib/src/rollbar.dart
@@ -18,7 +18,7 @@ class RollbarFlutter extends Rollbar {
 
   static Future<void> run(
       Config config, FutureOr<void> Function(RollbarFlutter) action) async {
-    if (config.handleUncaughtErrors!) {
+    if (config.handleUncaughtErrors ?? false) {
       var rollbar = RollbarFlutter._(config);
 
       await runZonedGuarded(() async {
@@ -27,9 +27,7 @@ class RollbarFlutter extends Rollbar {
         var previousOnError = FlutterError.onError;
         FlutterError.onError = (FlutterErrorDetails details) async {
           await rollbar._unhandledError(details.exception, details.stack ?? StackTrace.empty);
-          if (previousOnError != null) {
-            previousOnError.call(details);
-          }
+          previousOnError?.call(details);
         };
 
         var errorHandler = await (rollbar.errorHandler as Future<SendPort?>);

--- a/rollbar_flutter/lib/src/rollbar.dart
+++ b/rollbar_flutter/lib/src/rollbar.dart
@@ -26,7 +26,7 @@ class RollbarFlutter extends Rollbar {
 
         var previousOnError = FlutterError.onError;
         FlutterError.onError = (FlutterErrorDetails details) async {
-          await rollbar._unhandledError(details.exception, details.stack!);
+          await rollbar._unhandledError(details.exception, details.stack ?? StackTrace.empty);
           if (previousOnError != null) {
             previousOnError.call(details);
           }


### PR DESCRIPTION
## Description of the change

I'm regularly encountering exceptions on the `!` cast for `details.stack`. This most often occurs on UI exceptions. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
