### PR TITLE
Re-added development dependency_overrides

### DIFF
--- a/rollbar_dart/pubspec.yaml
+++ b/rollbar_dart/pubspec.yaml
@@ -17,6 +17,10 @@ dependencies:
   logging: ^1.0.2
   rollbar_common: ^0.3.1-beta
 
+dependency_overrides:
+  rollbar_common:
+    path: ../rollbar_common
+
 dev_dependencies:
   lints: '>=1.0.0 <3.0.0'
   test: ^1.16.0

--- a/rollbar_flutter/pubspec.yaml
+++ b/rollbar_flutter/pubspec.yaml
@@ -18,6 +18,12 @@ dependencies:
   rollbar_common: ^0.3.1-beta
   rollbar_dart: ^0.3.0-beta
 
+dependency_overrides:
+  rollbar_common:
+    path: ../rollbar_common
+  rollbar_dart:
+    path: ../rollbar_dart
+
 dev_dependencies:
   lints: '>=1.0.0 <3.0.0'
   flutter_lints: ^1.0.4


### PR DESCRIPTION
## Description of the change

We re-add the `dependency_overrides` we use in development.

New versions of Dart have fixed this, but we're still supporting an older one.

A `0.3.0-beta` has been added @ https://github.com/rollbar/rollbar-flutter/releases/tag/0.3.0-beta.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
