### PR TITLE
Suspend http transactions for 30 seconds in case of failure

### DIFF
--- a/rollbar_dart/lib/src/sender/http_sender.dart
+++ b/rollbar_dart/lib/src/sender/http_sender.dart
@@ -59,7 +59,7 @@ class HttpSender implements Sender {
 
       return true;
     } catch (error, stackTrace) {
-      _State.suspend(30.seconds);
+      if (!_State.suspended) _State.suspend(30.seconds);
 
       log('Exception sending payload',
           time: DateTime.now(),


### PR DESCRIPTION
## Description of the change

We were doing this through the `ConnectivityManager`, which was removed yesterday.

This adds the suspension back with the main goal of keeping this behavior for the next release.

A proper solution will come when https://github.com/rollbar/rollbar-flutter/issues/70 is addressed.

A proper solution will see the payload flow abstracted frp-style into a stream of payloads over time and just model the flow of time declaratively and without managing state instead of this horribleness.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Related to https://github.com/rollbar/rollbar-flutter/pull/69
- Related to https://github.com/rollbar/rollbar-flutter/issues/70

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
