### PR TITLE
Updated internal dep from Rollbar Apple SDK 1.x to 2.3.4.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "dart.flutterSdkPath": "/Users/matux/fvm/versions/3.0.5",
   // Remove .fvm files from search
   "search.exclude": {
     "**/.fvm": true

--- a/rollbar_flutter/example/ios/Podfile
+++ b/rollbar_flutter/example/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -27,6 +27,9 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 

--- a/rollbar_flutter/example/ios/Podfile.lock
+++ b/rollbar_flutter/example/ios/Podfile.lock
@@ -3,11 +3,18 @@ PODS:
     - Flutter
     - ReachabilitySwift
   - Flutter (1.0.0)
+  - PLCrashReporter (1.10.2)
   - ReachabilitySwift (5.0.0)
-  - Rollbar (1.12.14)
-  - rollbar_flutter (0.0.1):
+  - rollbar_flutter (1.2.0):
     - Flutter
-    - Rollbar (~> 1.12.14)
+    - RollbarNotifier (~> 2.3.4)
+    - RollbarPLCrashReporter (~> 2.3.4)
+  - RollbarCommon (2.3.4)
+  - RollbarNotifier (2.3.4):
+    - RollbarCommon (~> 2.3.4)
+  - RollbarPLCrashReporter (2.3.4):
+    - PLCrashReporter (~> 1.10.1)
+    - RollbarCommon (~> 2.3.4)
   - sqlite3 (3.39.3):
     - sqlite3/common (= 3.39.3)
   - sqlite3/common (3.39.3)
@@ -32,8 +39,11 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - PLCrashReporter
     - ReachabilitySwift
-    - Rollbar
+    - RollbarCommon
+    - RollbarNotifier
+    - RollbarPLCrashReporter
     - sqlite3
 
 EXTERNAL SOURCES:
@@ -49,12 +59,15 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   connectivity_plus: 413a8857dd5d9f1c399a39130850d02fe0feaf7e
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  PLCrashReporter: 2a08001f8e6a30abe405ee8f13d2753cfb5d682a
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  Rollbar: 58f315609433558a82af5a54d7888bb020bec561
-  rollbar_flutter: b7542ba065cdece3cef1b316c748d24d129ead51
+  rollbar_flutter: 9f339bf9f7dbc80265690846bd6b1cbb6e2e8c8b
+  RollbarCommon: 9a8198f5141aba65441c63e76b2ec4bc1a05cd2f
+  RollbarNotifier: 97b177c3493571f74cef5f793801c4a191f4d918
+  RollbarPLCrashReporter: bf0e742bd2d799d4c79a83108e4e7bfd6107db87
   sqlite3: 50117e9e063a9ef2b865f7bdf2f2601e5d368e9a
   sqlite3_flutter_libs: c6ab7f23670a98fef45a137159452004bc552168
 
-PODFILE CHECKSUM: f70cbe32e71f16c77469a29c52f47705f5041b7c
+PODFILE CHECKSUM: d2243213672c3c48aae53c36642ba411a6be7309
 
 COCOAPODS: 1.11.3

--- a/rollbar_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/rollbar_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -8,13 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		3621E63182A608FCC2F1AF6A /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1367B4919C8560FDCA797FA1 /* libPods-Runner.a */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		978B8F6F1D3862AE00F588F7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */; };
 		97C146F31CF9000F007C117D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 97C146F21CF9000F007C117D /* main.m */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		CA983656C878EC019B64828E /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFAF899D05FE95D1DEE08E52 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -31,7 +31,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		1367B4919C8560FDCA797FA1 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
@@ -49,6 +48,7 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BA51E93435F180AE31586B93 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		D2D4739B5BCFB234777F8D4A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		DFAF899D05FE95D1DEE08E52 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,7 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3621E63182A608FCC2F1AF6A /* libPods-Runner.a in Frameworks */,
+				CA983656C878EC019B64828E /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -130,7 +130,7 @@
 		E00D0E774CBD7FE183FEDA79 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				1367B4919C8560FDCA797FA1 /* libPods-Runner.a */,
+				DFAF899D05FE95D1DEE08E52 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -149,6 +149,8 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				C61E5DBB581C92D3DB00ADC9 /* [CP] Copy Pods Resources */,
+				925AF82D935326C27F96F91B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -242,6 +244,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		925AF82D935326C27F96F91B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -255,6 +274,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		C61E5DBB581C92D3DB00ADC9 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/rollbar_flutter/ios/rollbar_flutter.podspec
+++ b/rollbar_flutter/ios/rollbar_flutter.podspec
@@ -4,10 +4,10 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'rollbar_flutter'
-  s.version          = '0.0.1'
+  s.version          = '1.2.0'
   s.summary          = 'Connect your Flutter applications to Rollbar for error reporting.'
   s.description      = <<-DESC
-A new flutter plugin project.
+Connect your Flutter applications to Rollbar for error reporting.
                        DESC
   s.homepage         = 'http://example.com'
   s.license          = { :file => '../LICENSE' }
@@ -16,9 +16,12 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Rollbar', '~> 1.12.14'
-  s.platform = :ios, '8.0'
+  s.dependency 'RollbarNotifier', '~> 2.3.4'
+  s.dependency 'RollbarPLCrashReporter', '~> 2.3.4'
+  s.static_framework = true
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES',
+                            'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 end


### PR DESCRIPTION
## Description of the change

The Flutter SDK also runs the Rollbar Apple SDK internally in-order to catch crashes and errors that may happen in _native_ code. We were using a _very_ old version of the Rollbar Apple SDK which was causing compilation issues on Apple Silicon `arm64`.

This should not only take care of that issue, but improve the ability for users to catch errors and fix them while using the Flutter SDK.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [x] New release

## Related issues

- Fix https://app.shortcut.com/rollbar/story/118533/flutter-application-failing-to-build-on-ios-simulators

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
