### PR TITLE
Standard debug string representation of data objects.

### DIFF
--- a/rollbar_common/lib/rollbar_common.dart
+++ b/rollbar_common/lib/rollbar_common.dart
@@ -18,6 +18,7 @@ export 'src/table_set.dart';
 export 'src/data/payload_record.dart';
 export 'src/data/breadcrumb_record.dart';
 
+export 'src/debug.dart';
 export 'src/http.dart';
 export 'src/level.dart';
 export 'src/tuple.dart';

--- a/rollbar_common/lib/src/debug.dart
+++ b/rollbar_common/lib/src/debug.dart
@@ -1,0 +1,27 @@
+import 'dart:mirrors';
+
+import 'package:rollbar_common/rollbar_common.dart';
+
+mixin DebugStringRepresentation {
+  @override
+  String toString() {
+    final instanceMirror = reflect(this);
+
+    final classMirror = instanceMirror.type;
+    final className = MirrorSystem.getName(classMirror.simpleName);
+
+    final variables = classMirror.declarations.whereValueType<VariableMirror>();
+    final contents = variables.fold<List<String>>([], (acc, entry) {
+      final symbol = entry.key, declaration = entry.value;
+      final field = (declaration.isStatic ? classMirror : instanceMirror)
+          .getField(symbol);
+
+      final name = MirrorSystem.getName(declaration.simpleName);
+      final value = field.hasReflectee ? '${field.reflectee}' : '?';
+
+      return acc + ['$name: $value'];
+    }).join(', ');
+
+    return '$className($contents)';
+  }
+}

--- a/rollbar_common/lib/src/extension/collection.dart
+++ b/rollbar_common/lib/src/extension/collection.dart
@@ -118,6 +118,17 @@ extension MapExtensions<K, V> on Map<K, V> {
     return map;
   }
 
+  /// Returns a new Map by filtering its values that match the given type.
+  Map<K, U> whereValueType<U>() {
+    Map<K, U> map = {};
+
+    forEach((k, v) {
+      if (v is U) map[k] = v;
+    });
+
+    return map;
+  }
+
   bool any(KeyValuePredicate<K, V> p) {
     final it = entries.iterator;
     while (it.moveNext()) {

--- a/rollbar_common/test/debug_test.dart
+++ b/rollbar_common/test/debug_test.dart
@@ -1,0 +1,48 @@
+import 'dart:core';
+import 'package:test/test.dart';
+import 'package:rollbar_common/src/debug.dart';
+
+class OtherClass with DebugStringRepresentation {
+  final other = 'other_value';
+}
+
+class SomeClass with DebugStringRepresentation {
+  static const scnumber = 1234;
+  static final sfnumber = 4321;
+  static var svnumber = 5678;
+
+  final fnumber = 8765;
+  final object = OtherClass();
+  var vnumber = 7890;
+  var string = 'some_string';
+
+  // ignore: unused_field
+  final _private = 'some_private_var';
+
+  // ignore: prefer_function_declarations_over_variables
+  final closure = (String s) {};
+
+  SomeClass();
+
+  static void f() {}
+  void g() {}
+}
+
+void main() {
+  group('Debug Extensions', () {
+    test('Debug string representation', () async {
+      expect(
+          '${SomeClass()}',
+          'SomeClass('
+              'scnumber: 1234, '
+              'sfnumber: 4321, '
+              'svnumber: 5678, '
+              'fnumber: 8765, '
+              'object: OtherClass(other: other_value), '
+              'vnumber: 7890, '
+              'string: some_string, '
+              '_private: some_private_var, '
+              'closure: Closure: (String) => Null)');
+    });
+  });
+}

--- a/rollbar_dart/lib/src/data/config.dart
+++ b/rollbar_dart/lib/src/data/config.dart
@@ -19,7 +19,7 @@ abstract class Configurable {
 /// Configuration for the [Rollbar] notifier.
 @sealed
 @immutable
-class Config implements Serializable {
+class Config with DebugStringRepresentation implements Serializable {
   final String accessToken;
   final String endpoint;
   final String environment;

--- a/rollbar_dart/lib/src/data/context.dart
+++ b/rollbar_dart/lib/src/data/context.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+import 'package:rollbar_common/rollbar_common.dart';
 
 import 'payload/user.dart';
 import '../notifier/core_notifier.dart';
@@ -15,7 +16,7 @@ import '../persistence.dart';
 /// manipulation ought to occur in an encapsulated and controlled manner.
 /// See [CoreNotifier].
 @sealed
-class Context implements Configurable {
+class Context with DebugStringRepresentation implements Configurable {
   @override
   final Config config;
   final Telemetry telemetry;

--- a/rollbar_dart/lib/src/data/event.dart
+++ b/rollbar_dart/lib/src/data/event.dart
@@ -20,42 +20,32 @@ abstract class Notification implements Event {
 }
 
 @sealed
-class TelemetryEvent implements Event {
+class TelemetryEvent with DebugStringRepresentation implements Event {
   final Breadcrumb breadcrumb;
 
   const TelemetryEvent(this.breadcrumb);
-
-  @override
-  String toString() => 'TelemetryEvent(breadcrumb: $breadcrumb)';
 }
 
 @sealed
-class UserEvent implements Event {
+class UserEvent with DebugStringRepresentation implements Event {
   final User? user;
 
   const UserEvent(this.user);
-
-  @override
-  String toString() => 'UserEvent(user: $user)';
 }
 
 @sealed
-class MessageEvent implements Notification, Event {
+class MessageEvent
+    with DebugStringRepresentation
+    implements Notification, Event {
   @override
   final Level level;
   final String message;
 
-  const MessageEvent(
-    this.message, {
-    this.level = Level.info,
-  });
-
-  @override
-  String toString() => 'MessageEvent(level: $level, message: $message)';
+  const MessageEvent(this.message, {this.level = Level.info});
 }
 
 @sealed
-class ErrorEvent implements Notification, Event {
+class ErrorEvent with DebugStringRepresentation implements Notification, Event {
   @override
   final Level level;
   final dynamic error;
@@ -68,13 +58,6 @@ class ErrorEvent implements Notification, Event {
     this.description,
     this.level = Level.error,
   });
-
-  @override
-  String toString() => 'ErrorEvent('
-      'level: $level, '
-      'error: $error, '
-      'description: $description, '
-      'stackTrace: $stackTrace)';
 }
 
 @sealed

--- a/rollbar_dart/lib/src/data/payload/breadcrumb.dart
+++ b/rollbar_dart/lib/src/data/payload/breadcrumb.dart
@@ -6,7 +6,7 @@ enum Source { client, server }
 @sealed
 @immutable
 class Breadcrumb
-    with EquatableSerializableMixin
+    with EquatableSerializableMixin, DebugStringRepresentation
     implements Equatable, Serializable {
   final String type;
   final Level level;
@@ -112,12 +112,4 @@ class Breadcrumb
         'timestamp_ms': timestamp.microsecondsSinceEpoch,
         'body': body,
       };
-
-  @override
-  String toString() => 'Breadcrumb('
-      'type: $type, '
-      'level: $level, '
-      'source: $source, '
-      'body: $body, '
-      'timestamp_ms: $timestamp)';
 }

--- a/rollbar_dart/lib/src/data/payload/client.dart
+++ b/rollbar_dart/lib/src/data/payload/client.dart
@@ -4,7 +4,7 @@ import 'package:rollbar_common/rollbar_common.dart';
 @sealed
 @immutable
 class Client
-    with EquatableSerializableMixin
+    with EquatableSerializableMixin, DebugStringRepresentation
     implements Equatable, Serializable {
   final String locale;
   final String hostname;

--- a/rollbar_dart/lib/src/data/payload/data.dart
+++ b/rollbar_dart/lib/src/data/payload/data.dart
@@ -8,7 +8,9 @@ import 'user.dart' show User;
 /// Contains the data for the occurrence to be sent to Rollbar.
 @sealed
 @immutable
-class Data with EquatableSerializableMixin implements Serializable, Equatable {
+class Data
+    with EquatableSerializableMixin, DebugStringRepresentation
+    implements Serializable, Equatable {
   final Body body;
   final Level level;
   final JsonMap notifier;

--- a/rollbar_dart/lib/src/data/payload/exception_info.dart
+++ b/rollbar_dart/lib/src/data/payload/exception_info.dart
@@ -5,7 +5,7 @@ import 'package:rollbar_common/rollbar_common.dart';
 @sealed
 @immutable
 class ExceptionInfo
-    with EquatableSerializableMixin
+    with EquatableSerializableMixin, DebugStringRepresentation
     implements Equatable, Serializable {
   final String type;
   final String message;
@@ -31,10 +31,6 @@ class ExceptionInfo
           type: type ?? this.type,
           message: message ?? this.message,
           description: description ?? this.description);
-
-  @override
-  String toString() =>
-      'ExceptionInfo(type: $type, message: $message, description: $description)';
 
   @override
   JsonMap toMap() => {

--- a/rollbar_dart/lib/src/data/payload/payload.dart
+++ b/rollbar_dart/lib/src/data/payload/payload.dart
@@ -9,7 +9,7 @@ import 'data.dart';
 @sealed
 @immutable
 class Payload
-    with EquatableSerializableMixin
+    with EquatableSerializableMixin, DebugStringRepresentation
     implements Equatable, Serializable {
   final Data data;
 

--- a/rollbar_dart/lib/src/data/payload/user.dart
+++ b/rollbar_dart/lib/src/data/payload/user.dart
@@ -3,7 +3,9 @@ import 'package:rollbar_common/rollbar_common.dart';
 
 @sealed
 @immutable
-class User with EquatableSerializableMixin implements Equatable, Serializable {
+class User
+    with EquatableSerializableMixin, DebugStringRepresentation
+    implements Equatable, Serializable {
   final String id;
   final String? username;
   final String? email;

--- a/rollbar_dart/test/event_test.dart
+++ b/rollbar_dart/test/event_test.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:rollbar_common/rollbar_common.dart';
+import 'package:rollbar_dart/rollbar_dart.dart';
+import 'package:rollbar_dart/src/data/event.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Event tests', () {
+    test('Events carry the correct data', () async {
+      final telemetryEvent = TelemetryEvent(
+        Breadcrumb.log('Some breadcrumb'),
+      );
+      final userEvent = UserEvent(User(
+        id: '1234',
+        username: 'someUser',
+        email: 'some@email.com',
+      ));
+      final messageEvent = MessageEvent(
+        'Some message',
+        level: Level.debug,
+      );
+      final errorEvent = ErrorEvent(
+        ArgumentError('Invalid argument'),
+        StackTrace.empty,
+        description: 'Some description',
+        level: Level.critical,
+      );
+
+      final telemetryEventString = '$telemetryEvent';
+      final userEventString = '$userEvent';
+      final messageEventString = '$messageEvent';
+      final errorEventString = '$errorEvent';
+
+      expect(
+          telemetryEventString,
+          'TelemetryEvent(breadcrumb: Breadcrumb('
+          'type: log, '
+          'level: Level.info, '
+          'source: Source.client, '
+          'body: {message: Some breadcrumb}, '
+          'timestamp: ${telemetryEvent.breadcrumb.timestamp}))');
+
+      expect(
+          userEventString,
+          'UserEvent(user: User('
+          'id: 1234, username: someUser, email: some@email.com))');
+
+      expect(messageEventString,
+          'MessageEvent(level: Level.debug, message: Some message)');
+
+      expect(
+          errorEventString,
+          'ErrorEvent('
+          'level: Level.critical, '
+          'error: Invalid argument(s): Invalid argument, '
+          'description: Some description, '
+          'stackTrace: )');
+    });
+  });
+}


### PR DESCRIPTION
## Description of the change
Standardizes the debug string representation of data objects so they don't appear as "Instance of [SomeClass]" in the debugger and when printing.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- This was a simple chore that wasn't tracked.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
