### PR TITLE
Fixes an Android native unit test and Android example issue

### DIFF
--- a/rollbar_flutter/android/build.gradle
+++ b/rollbar_flutter/android/build.gradle
@@ -47,6 +47,16 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    testOptions {
+        unitTests.all {
+            testLogging {
+                events "passed", "skipped", "failed", "standardOut", "standardError"
+                outputs.upToDateWhen {false}
+                showStandardStreams = true
+            }
+        }
+    }
 }
 
 def flutterRoot =  System.getenv()['FLUTTER_SDK']
@@ -76,7 +86,7 @@ dependencies {
     testImplementation "io.flutter:flutter_embedding_debug:${flutterVersion}"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    testImplementation 'org.mockito:mockito-inline:3.8.0'
+    testImplementation 'org.mockito:mockito-inline:3.12.4'
     testImplementation 'com.google.code.gson:gson:2.8.6'
 }
 

--- a/rollbar_flutter/android/src/test/java/com/rollbar/flutter/RollbarMethodChannelTest.java
+++ b/rollbar_flutter/android/src/test/java/com/rollbar/flutter/RollbarMethodChannelTest.java
@@ -77,7 +77,10 @@ public class RollbarMethodChannelTest {
             stackTrace);
 
     if (CodecAdapter.canCaptureStackTrace()) {
-      assertThat(stackTrace.getValue(), startsWith("com.rollbar.flutter.RollbarTracePayload:"));
+      String stackTraceString = stackTrace.getValue();
+      if (stackTraceString != null) {
+        assertThat(stackTraceString, startsWith(TRACE_PAYLOAD_PREFIX));
+      }
     }
 
     String messageString = message.getValue();

--- a/rollbar_flutter/example/lib/main.dart
+++ b/rollbar_flutter/example/lib/main.dart
@@ -74,7 +74,7 @@ class MyHomePageState extends State<MyHomePage> {
       final int level = await platform.batteryLevel;
       batteryLevel = 'Battery at $level%.';
     } on PlatformException catch (e, stackTrace) {
-      batteryLevel = "Failed to get battery level: '${e.message}'.";
+      batteryLevel = 'Failed to get battery level.';
       Rollbar.drop(
         rollbar.Breadcrumb.error(
             'Non-fatal PlatformException while getting battery level.'),


### PR DESCRIPTION
## Description of the change

An Android unit test started to fail with Flutter SDK 3.7.

The function `encodeErrorEnvelopeWithStacktrace` on our mocked `MethodCodec` is being called without a stack trace, this call comes from the Flutter system. I've tracked this down to:
- https://api.flutter.dev/javadoc/io/flutter/plugin/common/MethodCodec.html#encodeErrorEnvelopeWithStacktrace(java.lang.String,java.lang.String,java.lang.Object,java.lang.String)

Where "errorStacktrace - Platform stacktrace for the error. possibly null."

So it seems it is correct that this may be null. I've added a check.

The library and example works fine regardless of the Flutter SDK version.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- This issue isn't being tracked.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
