### PR TITLE
Updated Flutter versions for the CI and fixed incorrect ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,17 @@ on:
 
 jobs:
   build_android:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Flutter version ${{ matrix.flutter_version }} (Android)
     strategy:
       matrix:
-        flutter_version: ['3.3.0']
+        flutter_version: ["3.10.2"]
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: '11.x'
+          java-version: "11.x"
       - uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8
         with:
           flutter-version: ${{ matrix.flutter_version }}
@@ -87,7 +87,7 @@ jobs:
     name: Flutter version ${{ matrix.flutter_version }} (iOS)
     strategy:
       matrix:
-        flutter_version: ['3.3.0']
+        flutter_version: ["3.10.2"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description of the change

This is a CI maintenance PR that bumps the Flutter version used to build to 3.10.2 and fixed the `runs-on` value that was specifying the ubuntu version instead of just using latest.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Not tracked

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
