### PR TITLE
Fixed onError callback not being set on the Flutter framework

### DIFF
--- a/rollbar_flutter/CHANGELOG.md
+++ b/rollbar_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.1
+
+- Fixed the SDK not hooking properly to the Flutter framework `onError` callback.
+
 ## 1.4.0
 
 - Updated the Rollbar Apple SDK used by this SDK to handle native-level errors and crashes to the latest 3.x version.

--- a/rollbar_flutter/example/pubspec.yaml
+++ b/rollbar_flutter/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rollbar_flutter_example
 description: Demonstrates how to use the rollbar_flutter plugin.
-version: 1.4.0
+version: 1.4.1
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 

--- a/rollbar_flutter/ios/rollbar_flutter.podspec
+++ b/rollbar_flutter/ios/rollbar_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'rollbar_flutter'
-  s.version          = '1.4.0'
+  s.version          = '1.4.1'
   s.summary          = 'Connect your Flutter applications to Rollbar for error reporting.'
   s.description      = <<-DESC
 Connect your Flutter applications to Rollbar for error reporting.

--- a/rollbar_flutter/lib/src/rollbar.dart
+++ b/rollbar_flutter/lib/src/rollbar.dart
@@ -59,7 +59,9 @@ class RollbarFlutter {
       transformer: (_) => PlatformTransformer(),
     ));
 
-    FlutterError.onError ??= onError;
+    if (onError != null) {
+      FlutterError.onError = onError;
+    }
 
     await _platform.initialize(config: config);
     await appRunner();

--- a/rollbar_flutter/pubspec.yaml
+++ b/rollbar_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rollbar_flutter
 description: Connect your Flutter applications to Rollbar for error reporting.
-version: 1.4.0
+version: 1.4.1
 homepage: https://www.rollbar.com
 documentation: https://docs.rollbar.com/docs/flutter#flutter
 repository: https://github.com/rollbar/rollbar-flutter


### PR DESCRIPTION
## Description of the change

This PR fixes a serious bug where the SDK wasn't properly hooking its `onError` callback to the Flutter framework which would prevent exceptions originating/or being caught by the Flutter Frameworks from being reported to Rollbar.

This PR also bumps the version to `1.4.1` as this is intended as a hot-fix to be published immediately upon merge.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [x] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
