### PR TITLE
Use new PlatformDispatcher onError method if available

### DIFF
--- a/rollbar_flutter/example/lib/main.dart
+++ b/rollbar_flutter/example/lib/main.dart
@@ -104,13 +104,21 @@ class MyHomePageState extends State<MyHomePage> {
 
     setState(() {
       if (++_counter % 2 == 0) {
-        throw ArgumentError('Unavoidable failure');
+        throw ArgumentError('Failed to increment counter');
       } else {
         Rollbar.drop(
           rollbar.Breadcrumb.log('Counter incremented to $_counter'),
         );
       }
     });
+  }
+
+  void asyncFailure() {
+    _asyncFailure(1).then((n) => log('$n ~/ 0 = ???'));
+  }
+
+  Future<int> _asyncFailure(int num) async {
+    return Future<int>.delayed(Duration(seconds: num), () => num ~/ 0);
   }
 
   void setUser() {
@@ -133,10 +141,10 @@ class MyHomePageState extends State<MyHomePage> {
     });
   }
 
-  void divideByZero() {
-    Rollbar.drop(rollbar.Breadcrumb.log('Tapped divideByZero button'));
-    Rollbar.critical('About to divide by zero, this won\'t work!');
-    1 ~/ 0;
+  void throwError() {
+    Rollbar.drop(rollbar.Breadcrumb.log('Tapped throwError button'));
+    Rollbar.critical('About to throw an error!');
+    throw StateError('A state error occurred');
   }
 
   void crash() {
@@ -157,10 +165,6 @@ class MyHomePageState extends State<MyHomePage> {
         child: const Text('Call Faulty Method'),
       ),
       Text(_faultyMsg),
-      ElevatedButton(
-        onPressed: divideByZero,
-        child: const Text('Divide by zero'),
-      ),
       if (Platform.isIOS)
         ElevatedButton(
           onPressed: crash,
@@ -170,6 +174,15 @@ class MyHomePageState extends State<MyHomePage> {
       ElevatedButton(
         onPressed: setUser,
         child: Text(_setUserText),
+      ),
+      const Divider(),
+      ElevatedButton(
+        onPressed: asyncFailure,
+        child: const Text('Async failure'),
+      ),
+      ElevatedButton(
+        onPressed: throwError,
+        child: const Text('Throw error'),
       ),
       const Divider(),
       const Text('Times you have pushed the plus button:'),

--- a/rollbar_flutter/lib/src/hooks/hook.dart
+++ b/rollbar_flutter/lib/src/hooks/hook.dart
@@ -1,0 +1,9 @@
+import 'dart:async';
+
+import 'package:rollbar_dart/rollbar.dart';
+
+abstract class Hook {
+  FutureOr<void> install(final Config config);
+
+  FutureOr<void> uninstall();
+}

--- a/rollbar_flutter/lib/src/hooks/platform_hook.dart
+++ b/rollbar_flutter/lib/src/hooks/platform_hook.dart
@@ -1,0 +1,34 @@
+import 'dart:ui';
+import 'package:rollbar_dart/rollbar.dart';
+import 'hook.dart';
+
+class PlatformHook implements Hook {
+  ErrorCallback? _originalOnError;
+  PlatformDispatcher? _platformDispatcher;
+
+  bool onError(Object exception, StackTrace stackTrace) {
+    Rollbar.error(exception, stackTrace);
+
+    if (_originalOnError != null) {
+      return _originalOnError!(exception, stackTrace);
+    }
+
+    return false;
+  }
+
+  @override
+  void install(_) {
+    _platformDispatcher = PlatformDispatcher.instance;
+    _originalOnError = _platformDispatcher?.onError;
+    _platformDispatcher?.onError = onError;
+  }
+
+  @override
+  void uninstall() {
+    if (_platformDispatcher?.onError == onError) {
+      _platformDispatcher?.onError = _originalOnError;
+      _originalOnError = null;
+      _platformDispatcher = null;
+    }
+  }
+}


### PR DESCRIPTION
## Description of the change

This PR implements the new recommended method to catch exceptions that don't occur within Flutter's callbacks according to https://docs.flutter.dev/testing/errors.

This swizzles the `PlatformDispatcher.onError` callback with our own callback which also calls the original one.

Previously, we were using a custom `Zone` to catch this class of exceptions but it was [deprecated in Flutter 3.3](https://medium.com/flutter/whats-new-in-flutter-3-3-893c7b9af1ff#:~:text=In%20this%20release%2C%20instead%20of%20using%20a%20custom%20Zone%2C%20you%20should%20catch%20all%20errors%20and%20exceptions%20by%20setting%20the%20PlatformDispatcher.onError%20callback).

We aim to preserve compatibility with Flutter < 3.3.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Resolves [SC-129017](https://app.shortcut.com/rollbar/story/129017/flutter-sdk-isn-t-catching-async-errors).
- Closes https://github.com/rollbar/rollbar-flutter/issues/101.
- Partial https://github.com/rollbar/rollbar-flutter/issues/90.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
