### PR TITLE
Initialize the native Rollbar/Android SDK as a hook instead of explicitly

### DIFF
--- a/rollbar_flutter/lib/src/hooks/native_hook.dart
+++ b/rollbar_flutter/lib/src/hooks/native_hook.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/services.dart';
+import 'package:rollbar_dart/rollbar.dart';
+
+import '../method_channel.dart';
+import 'hook.dart';
+
+class NativeHook implements Hook {
+  static const _platform = MethodChannel('com.rollbar.flutter');
+
+  @override
+  Future<void> install(final Config config) async {
+    await _platform.initialize(config: config);
+  }
+
+  @override
+  Future<void> uninstall() async {
+    await _platform.close();
+  }
+}

--- a/rollbar_flutter/lib/src/hooks/platform_hook.dart
+++ b/rollbar_flutter/lib/src/hooks/platform_hook.dart
@@ -6,6 +6,15 @@ class PlatformHook implements Hook {
   ErrorCallback? _originalOnError;
   PlatformDispatcher? _platformDispatcher;
 
+  static bool get isAvailable {
+    try {
+      (PlatformDispatcher.instance as dynamic)?.onError;
+      return true;
+    } on NoSuchMethodError {
+      return false;
+    }
+  }
+
   bool onError(Object exception, StackTrace stackTrace) {
     Rollbar.error(exception, stackTrace);
 

--- a/rollbar_flutter/lib/src/method_channel.dart
+++ b/rollbar_flutter/lib/src/method_channel.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/services.dart';
+import 'package:rollbar_flutter/rollbar_flutter.dart';
+
+extension RollbarMethodChannel on MethodChannel {
+  /// The platform-specific path where we can persist data if needed.
+  Future<String> get persistencePath async =>
+      await invokeMethod('persistencePath');
+
+  /// Initializes the native Apple/Android SDK Rollbar notifier
+  /// using the given configuration.
+  Future<void> initialize({required Config config}) async =>
+      await invokeMethod('initialize', config.toMap());
+
+  /// Unwinds the native Apple/Android SDK Rollbar notifier.
+  ///
+  /// This is a no-op at the moment.
+  Future<void> close() async => await invokeMethod('close');
+}

--- a/rollbar_flutter/lib/src/rollbar.dart
+++ b/rollbar_flutter/lib/src/rollbar.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
@@ -63,14 +62,5 @@ class RollbarFlutter {
     }
 
     await appRunner();
-  }
-
-  static bool get requiresCustomZone {
-    try {
-      (PlatformDispatcher.instance as dynamic)?.onError;
-      return false;
-    } on NoSuchMethodError {
-      return true;
-    }
   }
 }


### PR DESCRIPTION
## Description of the change

This PR encapsulates the initialization of the Rollbar/Android (native) SDK as another `Hook`, called the `NativeHook`.

This PR also encapsulate inside the `PlatformHook` the `as dynamic` hack we use to check whether the `PlatformDispatcher.onError` closure exists.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Related to [SC-129017](https://app.shortcut.com/rollbar/story/129017/flutter-sdk-isn-t-catching-async-errors)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
