### PR TITLE
Fixed breadcrumbs not being sorted correctly in obfuscated builds

### DIFF
--- a/rollbar_dart/CHANGELOG.md
+++ b/rollbar_dart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.1
+
+- Fixed breadcrumbs not being processed in the right order in obfuscated builds.
+
 ## 1.3.0
 
 - The log, debug, info, warn, error and critical methods in `Rollbar` now accept any type of object including `Error`, `Exception` and `String`. Dart objects that specialize `toString()` can be also passed and they'll be converted into their string representations.

--- a/rollbar_dart/example/pubspec.yaml
+++ b/rollbar_dart/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   logging: ^1.0.2
-  rollbar_dart: ^1.1.0
+  rollbar_dart: ^1.3.0
 
 dependency_overrides:
   rollbar_common:

--- a/rollbar_dart/lib/src/notifier/notifier.dart
+++ b/rollbar_dart/lib/src/notifier/notifier.dart
@@ -6,7 +6,7 @@ import 'package:rollbar_dart/rollbar_dart.dart';
 @sealed
 abstract class Notifier {
   // notifier version to be updated with each new release: [todo] automate
-  static const version = '1.3.0';
+  static const version = '1.3.1';
   static const name = 'rollbar-dart';
 
   FutureOr<Context> notify(Context state, final Event event);

--- a/rollbar_dart/lib/src/telemetry.dart
+++ b/rollbar_dart/lib/src/telemetry.dart
@@ -26,7 +26,7 @@ class Telemetry with Persistence<BreadcrumbRecord> implements Configurable {
       );
 
   List<Breadcrumb> breadcrumbs() => records
-      .sorted(by: #BreadcrumbRecord.timestamp)
+      .sorted(by: Symbol('${(BreadcrumbRecord).toString()}.timestamp'))
       .map((record) => jsonDecode(record.breadcrumb) as JsonMap)
       .map(Breadcrumb.fromMap)
       .toList();

--- a/rollbar_dart/pubspec.yaml
+++ b/rollbar_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rollbar_dart
 description: Connect your Dart applications to Rollbar for error reporting.
-version: 1.3.0
+version: 1.3.1
 homepage: https://www.rollbar.com
 documentation: https://docs.rollbar.com/docs/flutter#dart
 repository: https://github.com/rollbar/rollbar-flutter


### PR DESCRIPTION
## Description of the change

This PR solves an issue in the Dart SDK when dealing with obfuscated applications, where the Dart type system appears to deal with the `#` operator that creates a runtime `Symbol` identifier differently in obfuscated builds, that is, the type of the property is ignored.

This PR also bumps the version and updates the changelog.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
