### PR TITLE
chore: Bumping http & uuid versions

### DIFF
--- a/rollbar_common/pubspec.yaml
+++ b/rollbar_common/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  http: ^0.13.0
+  http: ^1.1.0
   collection: ^1.16.0
   sqlite3: ^1.7.0
-  uuid: ^3.0.0
+  uuid: ^4.1.0
   meta: ^1.7.0
 
 dev_dependencies:

--- a/rollbar_common/pubspec.yaml
+++ b/rollbar_common/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  http: ^1.1.0
+  http: '>=0.13.0 <2.0.0'
   collection: ^1.16.0
   sqlite3: ^1.7.0
   uuid: ^4.1.0

--- a/rollbar_dart/pubspec.yaml
+++ b/rollbar_dart/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  http: ^0.13.0
+  http: ^1.1.0
   meta: ^1.7.0
   sqlite3: ^1.7.0
   collection: ^1.16.0

--- a/rollbar_dart/pubspec.yaml
+++ b/rollbar_dart/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  http: ^1.1.0
+  http: '>=0.13.0 <2.0.0'
   meta: ^1.7.0
   sqlite3: ^1.7.0
   collection: ^1.16.0


### PR DESCRIPTION
## Description of the change

> Please include a summary of the change and which issues are fixed.
closes:  #115

`rollbar-flutter` cant really be used in newer flutter apps as the version of `http` and `uuid` are out of date. This simply bumps those packages. 

> Please also include relevant motivation and context.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix #115

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
