### PR TITLE
Replace removed `enabled` Gradle method calls with `required` properties

### DIFF
--- a/rollbar_flutter/android/build.gradle
+++ b/rollbar_flutter/android/build.gradle
@@ -104,8 +104,8 @@ task checkstyleMain(type: Checkstyle) {
     configFile file("$rootDir/tools/checkstyle/google_checks.xml")
     classpath = files()
     reports {
-        xml.enabled false
-        html.enabled true
+        xml.required = false
+        html.required = true
     }
 }
 
@@ -121,8 +121,8 @@ def makeCheckstyleTask(sourceSet, config) {
         configFile file("$rootDir/tools/checkstyle/${config}")
         classpath = files()
         reports {
-            xml.enabled false
-            html.enabled true
+            xml.required = false
+            html.required = true
         }
     }
 
@@ -159,7 +159,7 @@ task spotbugsMain(type: com.github.spotbugs.snom.SpotBugsTask) {
     release = project.version
     reports {
         html {
-            enabled = true
+            required = true
             destination = file("$buildDir/reports/spotbugs/main/spotbugs.html")
             stylesheet = 'fancy-hist.xsl'
         }


### PR DESCRIPTION
## Description of the change

Gradle 8 no longer allows the `xml.enbled true` method call and now uses the `xml.required= true` property.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

https://github.com/rollbar/rollbar-flutter/issues/119

## Checklists

### Development

- [x] Lint rules pass locally
- [N/A] The code changed/added as part of this pull request has been covered with tests
- [N/A] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
