### PR TITLE
Update RollbarNotifier dependency to 3.3.3

### DIFF
--- a/rollbar_flutter/ios/rollbar_flutter.podspec
+++ b/rollbar_flutter/ios/rollbar_flutter.podspec
@@ -16,7 +16,7 @@ Connect your Flutter applications to Rollbar for error reporting.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'RollbarNotifier', '~> 3.2.0'
+  s.dependency 'RollbarNotifier', '~> 3.3.3'
   s.static_framework = true
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
## Description of the change

This PR addresses [issue #136](https://github.com/rollbar/rollbar-flutter/issues/136), which reports build failures on iOS when using Xcode 18. To resolve this, the internal dependency RollbarNotifier has been updated to version 3.3.3. This update ensures compatibility with Xcode 18 and resolves the iOS build 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues
- Fix [#136](https://github.com/rollbar/rollbar-flutter/issues/136)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
