### PR TITLE
fix(android): add missing namespace to support AGP 7.0+

### DIFF
--- a/rollbar_flutter/android/build.gradle
+++ b/rollbar_flutter/android/build.gradle
@@ -33,6 +33,7 @@ apply plugin: 'checkstyle'
 apply plugin: "com.github.spotbugs"
 
 android {
+    namespace 'com.rollbar.flutter'
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
## Description of the change
Add missing namespace declaration in android/build.gradle to support Android Gradle Plugin (AGP) 7.0 and above.

```
Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
> Namespace not specified. Specify a namespace in the module's build file.
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues
[Bug: Build fails on AGP 7.0+ due to missing namespace ](https://github.com/rollbar/rollbar-flutter/issues/142)


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
